### PR TITLE
画像が添付できなかった問題を修正

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -192,7 +192,7 @@ class MediaAttachment < ApplicationRecord
   end
 
   def set_extension
-    extension = appropriate_extension
+    extension = appropriate_extension(file)
     basename  = Paperclip::Interpolations.basename(file, :original)
     file.instance_write :file_name, [basename, extension].delete_if(&:blank?).join('.')
   end


### PR DESCRIPTION
- media_attachmentの185行目、appropriate_extensionメソッド呼び出しで引数が不足していたため